### PR TITLE
Adjust header contrast and refresh typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
   <meta name="theme-color" content="#1c1c1c" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+    rel="stylesheet"
+  >
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,8 @@
 html, body { height: 100%; margin: 0; }
 html { scroll-behavior: smooth; }
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'IBM Plex Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, sans-serif;
   background: #1e1e1e;
   color: #f2f2f2;
   line-height: 1.45;
@@ -179,7 +180,7 @@ body.menu-open {
   font-size: clamp(30px, 6vw, 80px);
   font-weight: 600;
   letter-spacing: -0.01em;
-  color: rgba(255,255,255,0.85);
+  color: #ffffff;
   text-align: center;
   line-height: 1.2;
   padding-left: 10vw;
@@ -216,7 +217,7 @@ body.menu-open {
   padding-inline: clamp(12px, 6vw, 80px);
   text-align: center;
   font-size: clamp(26px, 5.2vw, 72px);
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: -0.012em;
   line-height: 1.18;
   color: rgba(255, 255, 255, 0.08);


### PR DESCRIPTION
## Summary
- switch the site font stack to IBM Plex Sans for a crisper, more contemporary tone
- brighten the hero heading color and align typography weights for consistency

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc7ac01048833183dff6e3806bb81f