### PR TITLE
Improve viewport unit fallback detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,9 +24,17 @@
   };
 
   const updateViewportUnit = () => {
-    const height = window.visualViewport?.height ?? window.innerHeight;
+    const candidates = [
+      window.visualViewport?.height,
+      window.innerHeight,
+      document.documentElement?.clientHeight,
+    ];
 
-    if (typeof height !== 'number' || !Number.isFinite(height) || height <= 0) {
+    const height = candidates.find(
+      (value) => typeof value === 'number' && Number.isFinite(value) && value > 0,
+    );
+
+    if (typeof height !== 'number') {
       scheduleRetry();
       return;
     }


### PR DESCRIPTION
## Summary
- gather viewport height candidates from visualViewport, innerHeight, and clientHeight
- only reschedule retries when no valid viewport height is available

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf056975f8833190d9b527b96441db