### PR TITLE
Update landing page branding to MESTO

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>CLASSNOE MESTO — Inspired Tribute</title>
-  <meta name="description" content="An homage to CLASSNOE MESTO's scrolling narrative experience." />
-  <meta property="og:title" content="CLASSNOE MESTO — Inspired Tribute" />
-  <meta property="og:description" content="An homage to CLASSNOE MESTO's scrolling narrative experience." />
+  <title>MESTO — Inspired Tribute</title>
+  <meta name="description" content="An homage to MESTO's scrolling narrative experience." />
+  <meta property="og:title" content="MESTO — Inspired Tribute" />
+  <meta property="og:description" content="An homage to MESTO's scrolling narrative experience." />
   <meta property="og:type" content="website" />
   <meta name="theme-color" content="#0b0b0b" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -27,9 +27,9 @@
           class="site-brand"
           type="button"
           data-scroll-to-sentences
-          aria-label="CLASSNOE MESTO — scroll to first message"
+          aria-label="MESTO — scroll to first message"
         >
-          CLASSNOE MESTO
+          MESTO
         </button>
       </div>
       <button
@@ -86,7 +86,7 @@
   </div>
 
   <main id="content" aria-labelledby="content-title">
-    <h1 id="content-title" class="visually-hidden">CLASSNOE MESTO inspired narrative</h1>
+    <h1 id="content-title" class="visually-hidden">MESTO inspired narrative</h1>
     <section id="sentences" role="list" aria-live="polite"></section>
   </main>
 
@@ -113,7 +113,7 @@
 
   <script>
     const SENTENCES = [
-      "CLASSNOE MESTO is a creative collective of designers, architects, musicians, filmmakers, writers, and engineers.",
+      "MESTO is a creative collective of designers, architects, musicians, filmmakers, writers, and engineers.",
       "We are fascinated by the traditions of craft and defined by the pursuit of excellence.",
       "We imagine and build products, experiences, and organizations in close partnership with leaders we admire.",
       "Our curiosity leads us to learn, to question, and to design with a respect for materials and for the people who use them.",


### PR DESCRIPTION
## Summary
- replace the page title, metadata, and aria label text so the landing page branding reads "MESTO"
- update the visible copy and scripted narrative so they reference the new MESTO name naturally

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf056875648331b5fce7474c0fa37c