### PR TITLE
Stabilize viewport unit against dynamic browser chrome

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -19,7 +19,7 @@
   }
 }
 
-@supports (height: 100dvh) {
+@supports (height: 100dvh) and not (height: 100svh) {
   :root {
     --viewport-unit: 1dvh;
   }


### PR DESCRIPTION
## Summary
- prefer the stable small viewport unit in CSS and only fall back to dvh when svh support is missing
- lock the JavaScript viewport-unit fallback to the initial non-keyboard height and ignore visualViewport-only growth from browser chrome
- carry the lock flag through deferred updates so keyboard toggles still resync the custom property without reacting to toolbar animations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf17d1dc8c8331816d2ae4135e3feb