### PR TITLE
Use stable viewport units for overscroll effects

### DIFF
--- a/script.js
+++ b/script.js
@@ -126,12 +126,39 @@
     });
   };
 
-  const applyViewportEffectsHeight = (value) => {
-    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+  const toViewportUnit = (value) => `${value / 100}px`;
+
+  const resolveLockedEffectsHeight = (value) => {
+    const lockedHeight =
+      typeof lockedViewportHeight === 'number' &&
+      Number.isFinite(lockedViewportHeight) &&
+      lockedViewportHeight > 0
+        ? lockedViewportHeight
+        : null;
+
+    if (lockedHeight == null) {
+      return value;
+    }
+
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return Math.max(lockedHeight, value);
+    }
+
+    return lockedHeight;
+  };
+
+  const applyViewportEffectsHeight = (value, { resolved = false } = {}) => {
+    const effectsHeight = resolved ? value : resolveLockedEffectsHeight(value);
+
+    if (
+      typeof effectsHeight !== 'number' ||
+      !Number.isFinite(effectsHeight) ||
+      effectsHeight <= 0
+    ) {
       return;
     }
 
-    const nextValue = `${value / 100}px`;
+    const nextValue = toViewportUnit(effectsHeight);
     if (root.style.getPropertyValue('--viewport-effects-unit') !== nextValue) {
       root.style.setProperty('--viewport-effects-unit', nextValue);
     }
@@ -142,11 +169,12 @@
     if (lock) {
       lockedViewportHeight = value;
     }
-    const nextValue = `${value / 100}px`;
+    const nextValue = toViewportUnit(value);
     if (root.style.getPropertyValue('--viewport-unit') !== nextValue) {
       root.style.setProperty('--viewport-unit', nextValue);
     }
-    applyViewportEffectsHeight(value);
+    const effectsHeight = resolveLockedEffectsHeight(value);
+    applyViewportEffectsHeight(effectsHeight, { resolved: true });
     broadcastViewportHeight(value);
   };
 

--- a/styles.css
+++ b/styles.css
@@ -21,16 +21,15 @@
   }
 }
 
-@supports (height: 100dvh) {
+@supports (height: 100lvh) {
   :root {
-    --viewport-effects-unit: 1dvh;
+    --viewport-effects-unit: 1lvh;
   }
 }
 
 @supports (height: 100dvh) and not (height: 100svh) {
   :root {
     --viewport-unit: 1dvh;
-    --viewport-effects-unit: 1dvh;
   }
 }
 


### PR DESCRIPTION
## Summary
- rely on `1lvh` (with a `1vh` fallback) for overscroll effect sizing so gradients ignore browser UI chrome
- update the JavaScript viewport fallback to keep the effects unit locked to the maximum height instead of shrinking with the visual viewport

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf22c0363883318c7aa8d9a711a187