### PR TITLE
Adjust overscroll gradient anchoring

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -124,8 +124,8 @@ body::after {
     );
   background-position:
     center calc(var(--overscroll-effects-bleed) + var(--safe-area-top) + var(--browser-chrome-top)),
-    center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-bottom) + var(--browser-chrome-bottom))),
-    center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-bottom) + var(--browser-chrome-bottom)));
+    center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-top) + var(--browser-chrome-bottom))),
+    center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-top) + var(--browser-chrome-bottom)));
   background-repeat: no-repeat;
   background-size:
     100% calc(clamp(160px, calc(var(--viewport-effects-unit) * 34), 360px) + var(--safe-area-top) + var(--browser-chrome-top)),


### PR DESCRIPTION
## Summary
- anchor the lower overscroll gradients to the viewport by using the safe-area top inset in body::after background positioning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfabf05bcc8331b38a7114d0fc9aa7