### PR TITLE
Run viewport helper on iOS WebKit despite svh support

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,7 +6,34 @@
   const supportsDynamicViewport =
     hasCSSSupports && (CSS.supports('height: 100dvh') || CSS.supports('height: 100svh'));
 
-  if (supportsDynamicViewport) {
+  const shouldForceDynamicViewportPolyfill = (() => {
+    if (typeof navigator !== 'object') {
+      return false;
+    }
+
+    const userAgent = typeof navigator.userAgent === 'string' ? navigator.userAgent : '';
+    const platform = typeof navigator.platform === 'string' ? navigator.platform : '';
+    const maxTouchPoints =
+      typeof navigator.maxTouchPoints === 'number' ? navigator.maxTouchPoints : 0;
+
+    const isAppleDevice =
+      /(iPad|iPhone|iPod)/i.test(platform) ||
+      /(iPad|iPhone|iPod)/i.test(userAgent) ||
+      (platform === 'MacIntel' && maxTouchPoints > 1);
+
+    if (!isAppleDevice) {
+      return false;
+    }
+
+    const isAppleWebKit = /AppleWebKit/i.test(userAgent);
+    if (!isAppleWebKit) {
+      return false;
+    }
+
+    return true;
+  })();
+
+  if (supportsDynamicViewport && !shouldForceDynamicViewportPolyfill) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- update the viewport helper guard to keep running on Apple WebKit touch devices even when `svh`/`dvh` units are reported as supported
- ensure `--browser-chrome-*` custom properties continue to reflect `visualViewport` offsets on devices like Dynamic Island iPhones

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfacf3803c8331b02bee33ab634fc5