### PR TITLE
Adjust bottom gradient safe area offsets

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -124,8 +124,8 @@ body::after {
     );
   background-position:
     center calc(var(--overscroll-effects-bleed) + var(--safe-area-top) + var(--browser-chrome-top)),
-    center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-top) + var(--browser-chrome-bottom))),
-    center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-top) + var(--browser-chrome-bottom)));
+    center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-bottom) + var(--browser-chrome-bottom))),
+    center calc(100% - (var(--overscroll-effects-bleed) + var(--safe-area-bottom) + var(--browser-chrome-bottom)));
   background-repeat: no-repeat;
   background-size:
     100% calc(clamp(160px, calc(var(--viewport-effects-unit) * 34), 360px) + var(--safe-area-top) + var(--browser-chrome-top)),


### PR DESCRIPTION
## Summary
- update the lower fade background positions to reference the bottom safe area inset
- keep background sizes aligned with the bottom safe area for smoother coverage of the home indicator

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d04d4a3ca883318d175c2c938500ba