### PR TITLE
Add reduced transparency media query overrides

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -662,3 +662,27 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
     scroll-behavior: auto !important;
   }
 }
+
+@media (prefers-reduced-transparency: reduce) {
+  body::before {
+    background: #050505;
+    opacity: 1;
+  }
+
+  body::after {
+    background: #050505;
+  }
+
+  .backdrop {
+    background: #050505;
+  }
+
+  .site-menu {
+    background: #050505;
+    backdrop-filter: none;
+  }
+
+  .site-menu__container {
+    background: #050505;
+  }
+}


### PR DESCRIPTION
## Summary
- add a prefers-reduced-transparency media query to provide opaque fallbacks
- ensure key overlay elements use solid backgrounds and avoid blur when reduced transparency is requested

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d04d4a36cc83319b6dc27a2fc5b383