### PR TITLE
Disable menu blur under reduced transparency

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -677,6 +677,17 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
     background: #050505;
   }
 
+  body.has-menu-open main,
+  body.has-menu-open footer,
+  body.has-menu-open .backdrop,
+  body.is-menu-closing main,
+  body.is-menu-closing footer,
+  body.is-menu-closing .backdrop {
+    filter: none !important;
+    opacity: 1 !important;
+    transition: none !important;
+  }
+
   .site-menu {
     background: #050505;
     backdrop-filter: none;


### PR DESCRIPTION
## Summary
- ensure the main content and backdrop skip blur/opacity effects when the reduced transparency preference is active
- neutralize related transitions so the menu overlay leaves content crisp under accessibility settings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d04f4873548331b27ade7904d75e23