### PR TITLE
Adjust sentence transforms for iOS devices

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -544,6 +544,28 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   transform: translate3d(0, 0, 0) scale(1);
 }
 
+@supports (-webkit-touch-callout: none) {
+  #sentences {
+    perspective: none;
+  }
+
+  .sentence {
+    transform: translateY(160px) scale(0.74);
+  }
+
+  .sentence.is-visible {
+    transform: translateY(80px) scale(0.83);
+  }
+
+  .sentence.is-past {
+    transform: translateY(-60px) scale(0.78);
+  }
+
+  .sentence.is-active {
+    transform: translateY(0) scale(1);
+  }
+}
+
 .site-footer {
   --site-footer-padding-top: clamp(80px, calc(var(--viewport-unit) * 18), 140px);
   --site-footer-padding-bottom: clamp(60px, calc(var(--viewport-unit) * 18), 160px);


### PR DESCRIPTION
## Summary
- wrap the sentence animations in an iOS-specific @supports block to disable perspective
- replace translate3d usage with translateY/scale equivalents so iOS keeps the original depth feel without extra GPU layers

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d055a26bd88331bcbdcb04b09404e2